### PR TITLE
Catch ReflectionTypeLoadException, add stuff to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-﻿bin
+﻿*.vsidx
+*.dtbcache*
+*.suo
+bin
 obj
 /.idea
 /*.DotSettings.user

--- a/SlopCrewClient/Patches/CustomAppAPIPatch.cs
+++ b/SlopCrewClient/Patches/CustomAppAPIPatch.cs
@@ -24,18 +24,31 @@ internal class CustomAppAPIPatch {
     //   private static IEnumerable<Type> FindDerivedTypes(Assembly assembly, Type baseType) {
     //     return assembly.GetTypes().Where(t => baseType.IsAssignableFrom(t) && t != baseType);
     private static bool FindDerivedTypes_Prefix(Assembly assembly, Type baseType, ref IEnumerable<Type> __result) {
-        __result = assembly.GetTypes().Where(t => {
-            try {
-                return baseType.IsAssignableFrom(t) && t != baseType;
-            } catch(Exception e) {
-                if (e is TypeLoadException || e is ReflectionTypeLoadException) {
-                    // Swallow it
-                    return false;
+        // Assemblies can throw typeload exceptions.
+        try {
+            __result = assembly.GetTypes().Where(t => {
+                // Or the types inside the assemblies.
+                try {
+                    return baseType.IsAssignableFrom(t) && t != baseType;
                 }
-                else
-                    throw;
+                catch (Exception e) {
+                    if (e is TypeLoadException || e is ReflectionTypeLoadException) {
+                        // Swallow it
+                        return false;
+                    }
+                    else
+                        throw;
+                }
+            });
+        }
+        catch (Exception e) {
+            if (e is TypeLoadException || e is ReflectionTypeLoadException) {
+                // Swallow it
+                return false;
             }
-        });
+            else
+                throw;
+        }
         return false;
     }
 }

--- a/SlopCrewClient/Patches/CustomAppAPIPatch.cs
+++ b/SlopCrewClient/Patches/CustomAppAPIPatch.cs
@@ -27,9 +27,13 @@ internal class CustomAppAPIPatch {
         __result = assembly.GetTypes().Where(t => {
             try {
                 return baseType.IsAssignableFrom(t) && t != baseType;
-            } catch(TypeLoadException e) {
-                // Swallow it
-                return false;
+            } catch(Exception e) {
+                if (e is TypeLoadException || e is ReflectionTypeLoadException) {
+                    // Swallow it
+                    return false;
+                }
+                else
+                    throw;
             }
         });
         return false;


### PR DESCRIPTION
While TypeLoadException is caught in the CustomAppAPI patch, ReflectionTypeLoadException can still be thrown which can still cause black screens for players using the client without SlopCrew.

This PR catches both exceptions and also adds a few user and cache files to the .gitignore